### PR TITLE
Move deviceplugin, podresources to tools

### DIFF
--- a/pkg/tools/deviceplugin/client.go
+++ b/pkg/tools/deviceplugin/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/deviceplugin/client_test.go
+++ b/pkg/tools/deviceplugin/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/networkservicemesh/sdk-k8s/pkg/deviceplugin"
+	"github.com/networkservicemesh/sdk-k8s/pkg/tools/deviceplugin"
 )
 
 const (

--- a/pkg/tools/podresources/client.go
+++ b/pkg/tools/podresources/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
# Motivation
`deviceplugin`, `podresources` are not enough valuable to be located in the `pkg` root.


Closes https://github.com/networkservicemesh/sdk-k8s/issues/11