### PR TITLE
Update go.mod and go.sum to latest version from networkservicemesh/sd…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.2
 	github.com/networkservicemesh/api v0.0.0-20210112152104-45029fb10e27
-	github.com/networkservicemesh/sdk v0.0.0-20210113103247-8c04922e9e48
+	github.com/networkservicemesh/sdk v0.0.0-20210113183230-a7a5294511d8
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRf
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/networkservicemesh/api v0.0.0-20210112152104-45029fb10e27 h1:J0UPj3sYfEvXwMHyAOiQ++NU7a3cZGZST1s1ftyC0uQ=
 github.com/networkservicemesh/api v0.0.0-20210112152104-45029fb10e27/go.mod h1:qvxdY1Zt4QTtiG+uH1XmjpegeHjlt5Jj4A8iK55iJPI=
-github.com/networkservicemesh/sdk v0.0.0-20210113103247-8c04922e9e48 h1:jJjD1GvUdezDPN1GqJ7TDPLwYgql9r253RKZ1uX0Srs=
-github.com/networkservicemesh/sdk v0.0.0-20210113103247-8c04922e9e48/go.mod h1:LV9NIA44LDUs0moEnrfeeRKQPA3Qdu3JiBhSwzEbXSM=
+github.com/networkservicemesh/sdk v0.0.0-20210113183230-a7a5294511d8 h1:mjTppLQzDCypRV6Upbea6m8WBvmt3dE15Bx/3RqPzGw=
+github.com/networkservicemesh/sdk v0.0.0-20210113183230-a7a5294511d8/go.mod h1:LV9NIA44LDUs0moEnrfeeRKQPA3Qdu3JiBhSwzEbXSM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=


### PR DESCRIPTION
…k@master networkservicemesh/sdk#649

networkservicemesh/sdk PR link: https://github.com/networkservicemesh/sdk/pull/649

networkservicemesh/sdk commit message:
commit a7a5294511d8bb803fe6fa959345535e76b2c002
Author: Denis Tingaikin <49399980+denis-tingaikin@users.noreply.github.com>
Date:   Thu Jan 14 01:32:30 2021 +0700

    fix: expire chain element could work incorrectly with registry-k8s (#649)

    * fix couple issues of expire chain element

    Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

    * fix linter issues

    Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

Signed-off-by: NSMBot <nsmbot@networkservicmesh.io>