### PR TITLE
fix: updates from nsmbot doesn't produce updates to dependent repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,15 +152,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ github.repository }}
+          ref: master
+          fetch-depth: '0'
       - name: Create commit message
         working-directory: ${{ github.repository }}
         run: |
-          echo "Update go.mod and go.sum to latest version from ${{ github.repository }}@master ${{ github.repository }}#${{ steps.findPr.outputs.pr }}" >> /tmp/commit-message
+          echo "Update go.mod and go.sum to latest version from ${{ github.repository }}@master ${{ github.repository }}#${{ github.event.number }}" >> /tmp/commit-message
           echo "" >> /tmp/commit-message
           echo "${{ github.repository }} PR link: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}" >> /tmp/commit-message
           echo "" >> /tmp/commit-message
           echo "${{ github.repository }} commit message:" >> /tmp/commit-message
-          git log master... >> /tmp/commit-message
+          git log -1 >> /tmp/commit-message
           echo "Commit Message:"
           cat /tmp/commit-message
       - name: Checkout networkservicemesh/${{ matrix.repository }}
@@ -175,7 +177,7 @@ jobs:
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |
-          GOPROXY=direct go get -u github.com/${{ github.repository }}
+          GOPRIVATE=github.com/networkservicemesh go get -u github.com/${{ github.repository }}
           go mod tidy
           git diff
       - name: Push update to the ${{ matrix.repository }}
@@ -185,6 +187,10 @@ jobs:
           git config --global user.email "nsmbot@networkservicmesh.io"
           git config --global user.name "NSMBot"
           git add go.mod go.sum
+          if ! [ -n "$(git diff --cached --exit-code)" ]; then
+            echo ${{ matrix.repository }} is up to date
+            exit 0;
+          fi
           git commit -s -F /tmp/commit-message
           git checkout -b update/${{ github.repository }}
           git push -f origin update/${{ github.repository }}


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

Fixes https://github.com/networkservicemesh/sdk-k8s/runs/1760566281