### PR TITLE
fix: add missed serialize chain elements

### DIFF
--- a/pkg/registry/chains/registryk8s/registry-k8s.go
+++ b/pkg/registry/chains/registryk8s/registry-k8s.go
@@ -29,6 +29,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/expire"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/proxy"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/serialize"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 
 	"github.com/networkservicemesh/sdk-k8s/pkg/registry/etcd"
@@ -47,6 +48,7 @@ type Config struct {
 // NewServer creates new registry server based on k8s etcd db storage
 func NewServer(config *Config, options ...grpc.DialOption) registryserver.Registry {
 	nseChain := chain.NewNetworkServiceEndpointRegistryServer(
+		serialize.NewNetworkServiceEndpointRegistryServer(),
 		expire.NewNetworkServiceEndpointRegistryServer(config.ChainCtx, config.ExpirePeriod),
 		checkid.NewNetworkServiceEndpointRegistryServer(),
 		etcd.NewNetworkServiceEndpointRegistryServer(config.ChainCtx, config.Namespace, config.ClientSet),
@@ -58,6 +60,7 @@ func NewServer(config *Config, options ...grpc.DialOption) registryserver.Regist
 		}, connect.WithClientDialOptions(options...)),
 	)
 	nsChain := chain.NewNetworkServiceRegistryServer(
+		serialize.NewNetworkServiceRegistryServer(),
 		etcd.NewNetworkServiceRegistryServer(config.ChainCtx, config.Namespace, config.ClientSet),
 		proxy.NewNetworkServiceRegistryServer(config.ProxyRegistryURL),
 		connect.NewNetworkServiceRegistryServer(config.ChainCtx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

When https://github.com/networkservicemesh/sdk/commit/9b80b5547ab698edcfe5080c72d7effc66344b63 had landed no one is not updated sdk-k8s registry.

Now testing could fail https://github.com/networkservicemesh/integration-k8s-kind/pull/215 by missed serialize chain element by error:
```
2021-05-11T15:04:03.219435588Z panic: runtime error: invalid memory address or nil pointer dereference
2021-05-11T15:04:03.219447688Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x903b42]
2021-05-11T15:04:03.219451088Z 
2021-05-11T15:04:03.219455688Z goroutine 167 [running]:
2021-05-11T15:04:03.219459788Z github.com/networkservicemesh/sdk/pkg/tools/serializectx.(*Executor).AsyncExec(0x0, 0xc0006d56b0, 0x440516)
2021-05-11T15:04:03.219463688Z 	/go/pkg/mod/github.com/networkservicemesh/sdk@v0.0.0-20210511142251-93d252947219/pkg/tools/serializectx/executor.go:27 +0x22
2021-05-11T15:04:03.219467188Z github.com/networkservicemesh/sdk/pkg/tools/expire.(*Manager).New.func1()
2021-05-11T15:04:03.219470588Z 	/go/pkg/mod/github.com/networkservicemesh/sdk@v0.0.0-20210511142251-93d252947219/pkg/tools/expire/manager.go:64 +0xdb
2021-05-11T15:04:03.219473989Z created by time.goFunc
2021-05-11T15:04:03.219477489Z 	/usr/local/go/src/time/sleep.go:180 +0x45
```