### PR TITLE
[qfix] Fix createpod name generation

### DIFF
--- a/pkg/networkservice/common/createpod/option.go
+++ b/pkg/networkservice/common/createpod/option.go
@@ -37,7 +37,7 @@ func WithLabelsKey(labelsKey string) Option {
 }
 
 // WithNameGenerator sets function to be used for pod name generation.
-// Default behavior is to append "-nodeName=<nodeName>" to the template name.
+// Default behavior is to append "--on-node--<nodeName>" to the template name.
 func WithNameGenerator(nameGenerator func(templateName, nodeName string) string) Option {
 	return func(t *createPodServer) {
 		t.nameGenerator = nameGenerator

--- a/pkg/networkservice/common/createpod/server.go
+++ b/pkg/networkservice/common/createpod/server.go
@@ -52,7 +52,7 @@ func NewServer(client kubernetes.Interface, podTemplate *corev1.Pod, options ...
 		namespace:   "default",
 		labelsKey:   "NSM_LABELS",
 		nameGenerator: func(templateName, nodeName string) string {
-			return templateName + "-nodeName=" + nodeName
+			return templateName + "--on-node--" + nodeName
 		},
 	}
 

--- a/pkg/networkservice/common/createpod/server_test.go
+++ b/pkg/networkservice/common/createpod/server_test.go
@@ -68,7 +68,7 @@ func TestCreatePod_RepeatedRequest(t *testing.T) {
 		Connection: &networkservice.Connection{},
 	})
 	require.Error(t, err)
-	require.Equal(t, "pods \""+podTemplate.ObjectMeta.Name+"-nodeName="+nodeName1+"\" already exists", err.Error())
+	require.Equal(t, "pods \""+podTemplate.ObjectMeta.Name+"--on-node--"+nodeName1+"\" already exists", err.Error())
 
 	podList, err := clientSet.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

Currently by default `createpod` element uses name `<podName>-nodeName=<nodeName>` for created pods, and such names are not valid pod names in kubernetes. Names must only consist of lower case alphanumeric characters, `-` or `.`.
This PR fixes default name generation function.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
