### PR TITLE
fix: custom resources NS/NSE metadata should be mapped into  NS/NSE names

### DIFF
--- a/pkg/registry/etcd/ns_server.go
+++ b/pkg/registry/etcd/ns_server.go
@@ -104,6 +104,9 @@ func (n *etcdNSRegistryServer) Find(query *registry.NetworkServiceQuery, s regis
 	}
 	for i := 0; i < len(list.Items); i++ {
 		item := (*registry.NetworkService)(&list.Items[i].Spec)
+		if item.Name == "" {
+			item.Name = list.Items[i].Name
+		}
 		if matchutils.MatchNetworkServices(query.NetworkService, item) {
 			err := s.Send(item)
 			if err != nil {

--- a/pkg/registry/etcd/nse_server.go
+++ b/pkg/registry/etcd/nse_server.go
@@ -81,6 +81,9 @@ func (n *etcdNSERegistryServer) Find(query *registry.NetworkServiceEndpointQuery
 	}
 	for i := 0; i < len(list.Items); i++ {
 		item := (*registry.NetworkServiceEndpoint)(&list.Items[i].Spec)
+		if item.Name == "" {
+			item.Name = list.Items[i].Name
+		}
 		if matchutils.MatchNetworkServiceEndpoints(query.NetworkServiceEndpoint, item) {
 			err := s.Send(item)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

Closes https://github.com/networkservicemesh/deployments-k8s/issues/2008