### PR TITLE
fixed error when using get with empty namespace

### DIFF
--- a/pkg/registry/etcd/ns_server.go
+++ b/pkg/registry/etcd/ns_server.go
@@ -58,11 +58,10 @@ func (n *etcdNSRegistryServer) Register(ctx context.Context, request *registry.N
 		metav1.CreateOptions{},
 	)
 	if apierrors.IsAlreadyExists(err) {
-		var exist *v1.NetworkService
-		exist, err = n.client.NetworkservicemeshV1().NetworkServices("").Get(ctx, request.Name, metav1.GetOptions{})
+		var ns *v1.NetworkService
+		ns, err = n.findNetworkService(ctx, request)
 		if err == nil {
-			exist.Spec = *(*v1.NetworkServiceSpec)(request)
-			apiResp, err = n.client.NetworkservicemeshV1().NetworkServices(n.ns).Update(ctx, exist, metav1.UpdateOptions{})
+			apiResp, err = n.client.NetworkservicemeshV1().NetworkServices(n.ns).Update(ctx, ns, metav1.UpdateOptions{})
 		}
 	}
 	if err != nil {
@@ -173,4 +172,23 @@ func NewNetworkServiceRegistryServer(chainContext context.Context, ns string, cl
 		client:       client,
 		ns:           ns,
 	}
+}
+
+func (n *etcdNSRegistryServer) findNetworkService(ctx context.Context, ns *registry.NetworkService) (*v1.NetworkService, error) {
+	list, err := n.client.NetworkservicemeshV1().NetworkServices("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(list.Items); i++ {
+		item := (*registry.NetworkService)(&list.Items[i].Spec)
+		if item.Name == "" {
+			item.Name = list.Items[i].Name
+		}
+		if ns.Name == item.Name {
+			list.Items[i].Spec = *(*v1.NetworkServiceSpec)(ns)
+			return &list.Items[i], nil
+		}
+	}
+
+	return nil, errors.New("network service not found")
 }

--- a/pkg/registry/etcd/nse_server.go
+++ b/pkg/registry/etcd/nse_server.go
@@ -63,8 +63,22 @@ func (n *etcdNSERegistryServer) Register(ctx context.Context, request *registry.
 	)
 	if apierrors.IsAlreadyExists(err) {
 		var nse *v1.NetworkServiceEndpoint
-		nse, err = n.findNetworkServiceEndpoint(ctx, request)
-		if err == nil {
+		list, erro := n.client.NetworkservicemeshV1().NetworkServiceEndpoints("").List(ctx, metav1.ListOptions{})
+		if erro != nil {
+			return nil, erro
+		}
+		for i := 0; i < len(list.Items); i++ {
+			item := (*registry.NetworkServiceEndpoint)(&list.Items[i].Spec)
+			if item.Name == "" {
+				item.Name = list.Items[i].Name
+			}
+			if request.Name == item.Name {
+				list.Items[i].Spec = *(*v1.NetworkServiceEndpointSpec)(request)
+				nse = &list.Items[i]
+			}
+		}
+
+		if nse != nil {
 			apiResp, err = n.client.NetworkservicemeshV1().NetworkServiceEndpoints(n.ns).Update(ctx, nse, metav1.UpdateOptions{})
 		}
 	}
@@ -179,23 +193,4 @@ func NewNetworkServiceEndpointRegistryServer(chainContext context.Context, ns st
 		client:       client,
 		ns:           ns,
 	}
-}
-
-func (n *etcdNSERegistryServer) findNetworkServiceEndpoint(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*v1.NetworkServiceEndpoint, error) {
-	list, err := n.client.NetworkservicemeshV1().NetworkServiceEndpoints("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	for i := 0; i < len(list.Items); i++ {
-		item := (*registry.NetworkServiceEndpoint)(&list.Items[i].Spec)
-		if item.Name == "" {
-			item.Name = list.Items[i].Name
-		}
-		if nse.Name == item.Name {
-			list.Items[i].Spec = *(*v1.NetworkServiceEndpointSpec)(nse)
-			return &list.Items[i], nil
-		}
-	}
-
-	return nil, errors.New("network service not found")
 }


### PR DESCRIPTION
Signed-off-by: Mikhail Avramenko <avramenkomihail15@gmail.com>

## Description
k8s api rest methods not working properly with empty namespaces, so changed get to list

## Issue
part of https://github.com/networkservicemesh/sdk-k8s/issues/252