### PR TITLE
Add dependent repository cmd-forwarder-ovs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,10 +45,11 @@ jobs:
       matrix:
         repository:
           - cmd-exclude-prefixes-k8s
+          - cmd-forwarder-ovs
           - cmd-forwarder-sriov
-          - cmd-registry-k8s
-          - cmd-nse-supplier-k8s
           - cmd-forwarder-vpp
+          - cmd-nse-supplier-k8s
+          - cmd-registry-k8s
     name: Update ${{ matrix.repository }}
     needs: create-release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependent-repositories.yaml
+++ b/.github/workflows/update-dependent-repositories.yaml
@@ -17,10 +17,11 @@ jobs:
       matrix:
         repository:
           - cmd-exclude-prefixes-k8s
+          - cmd-forwarder-ovs
           - cmd-forwarder-sriov
-          - cmd-registry-k8s
-          - cmd-nse-supplier-k8s
           - cmd-forwarder-vpp
+          - cmd-nse-supplier-k8s
+          - cmd-registry-k8s
     name: Update ${{ matrix.repository }}
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}


### PR DESCRIPTION
[`sdk-k8s` is used by `cmd-forwarder-ovs`](https://github.com/networkservicemesh/cmd-forwarder-ovs/blob/1058c36d1a778cbf70e61fe71afdb8ee673933a0/go.mod#L12), but workflow yaml files were missing this dependency. This PR fixes this.