### PR TITLE
qfix: replace POD_NAME and remove NODE_NAME from createpod chain element

### DIFF
--- a/pkg/networkservice/common/createpod/server.go
+++ b/pkg/networkservice/common/createpod/server.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	nodeNameKey = "nodeName"
-	createdBy   = "spawnedBy"
+	createdBy   = "createdBy"
 )
 
 type createPodServer struct {
@@ -69,8 +69,7 @@ func NewServer(ctx context.Context, client kubernetes.Interface, podTemplate str
 		client:       client,
 		myNamespace:  "default",
 		deserializer: deserializer,
-		myNode:       os.Getenv("NODE_NAME"),
-		myName:       os.Getenv("POD_NAME"),
+		myName:       os.Getenv("HOSTNAME"),
 	}
 
 	for _, opt := range options {

--- a/pkg/networkservice/common/createpod/server.go
+++ b/pkg/networkservice/common/createpod/server.go
@@ -50,7 +50,6 @@ type createPodServer struct {
 	deserializer runtime.Decoder
 	podTemplate  string
 	myNamespace  string
-	myNode       string
 	myName       string
 }
 

--- a/pkg/networkservice/common/createpod/server_test.go
+++ b/pkg/networkservice/common/createpod/server_test.go
@@ -68,7 +68,7 @@ objectmeta:
 
 	clientSet := fake.NewSimpleClientset()
 
-	err := os.Setenv("POD_NAME", "supplier-1")
+	err := os.Setenv("HOSTNAME", "supplier-1")
 	require.NoError(t, err)
 
 	server := next.NewNetworkServiceServer(
@@ -146,7 +146,7 @@ objectmeta:
 
 	clientSet := fake.NewSimpleClientset()
 
-	err := os.Setenv("POD_NAME", "supplier-1")
+	err := os.Setenv("HOSTNAME", "supplier-1")
 	require.NoError(t, err)
 
 	server := next.NewNetworkServiceServer(
@@ -223,7 +223,7 @@ objectmeta:
 
 	clientSet := fake.NewSimpleClientset()
 
-	err := os.Setenv("POD_NAME", "supplier-1")
+	err := os.Setenv("HOSTNAME", "supplier-1")
 	require.NoError(t, err)
 
 	server := next.NewNetworkServiceServer(
@@ -270,7 +270,7 @@ objectmeta:
 
 	clientSet := fake.NewSimpleClientset()
 
-	err := os.Setenv("POD_NAME", "supplier-1")
+	err := os.Setenv("HOSTNAME", "supplier-1")
 	require.NoError(t, err)
 
 	server := next.NewNetworkServiceServer(


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


## Motivation

`HOSTNAME` is one of simplest ways to get name of the POD in k8s.